### PR TITLE
feat: incluir quantidade de propostas no histórico de causas

### DIFF
--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/Causa/CausaResponseDTO.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/Causa/CausaResponseDTO.java
@@ -2,5 +2,16 @@ package advogados_popular.api_advogados_popular.DTOs.Causa;
 
 import advogados_popular.api_advogados_popular.DTOs.statusCausa;
 
-public record CausaResponseDTO(Long id, String titulo, String descricao, String usuarioNome, statusCausa status) {}
+/**
+ * Representa os dados retornados para uma {@link advogados_popular.api_advogados_popular.Entitys.Causa}.
+ * Inclui a quantidade de propostas associadas à causa.
+ */
+public record CausaResponseDTO(
+        Long id,
+        String titulo,
+        String descricao,
+        String usuarioNome,
+        statusCausa status,
+        long quantidadePropostas
+) {}
 

--- a/src/main/java/advogados_popular/api_advogados_popular/Repositorys/PropostaRepository.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/Repositorys/PropostaRepository.java
@@ -11,4 +11,6 @@ public interface PropostaRepository extends JpaRepository<Proposta, Long> {
     boolean existsByAdvogadoAndCausa(Advogado advogado, Causa causa);
     List<Proposta> findByCausa(Causa causa);
     List<Proposta> findByAdvogado(Advogado advogado);
+
+    long countByCausa(Causa causa);
 }

--- a/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
@@ -57,7 +57,8 @@ public class CausaService {
                         causa.getTitulo(),
                         causa.getDescricao(),
                         causa.getUsuario().getNome(),
-                        causa.getStatus()
+                        causa.getStatus(),
+                        propostaRepository.countByCausa(causa)
                 ))
                 .toList();
     }
@@ -80,7 +81,8 @@ public class CausaService {
                             c.getTitulo(),
                             c.getDescricao(),
                             usuario.getNome(),
-                            c.getStatus()
+                            c.getStatus(),
+                            propostaRepository.countByCausa(c)
                     ))
                     .toList();
         } else if (account.getRole() == Role.ADVOGADO) {
@@ -95,7 +97,8 @@ public class CausaService {
                             c.getTitulo(),
                             c.getDescricao(),
                             c.getUsuario().getNome(),
-                            c.getStatus()
+                            c.getStatus(),
+                            propostaRepository.countByCausa(c)
                     ))
                     .toList();
         } else {
@@ -129,7 +132,8 @@ public class CausaService {
                 salvo.getTitulo(),
                 salvo.getDescricao(),
                 usuario.getNome(),
-                salvo.getStatus()
+                salvo.getStatus(),
+                0
         );
     }
 }


### PR DESCRIPTION
## Summary
- adicionar campo `quantidadePropostas` ao CausaResponseDTO
- expor contagem de propostas em listagens e histórico de causas
- permitir consultar quantidade de propostas via PropostaRepository

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeab00f60c8325ad6246a3755da9f6