### PR TITLE
feat: add payment options and lawyer details

### DIFF
--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/Advogados/AdvogadoRequestDTO.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/Advogados/AdvogadoRequestDTO.java
@@ -2,5 +2,11 @@ package advogados_popular.api_advogados_popular.DTOs.Advogados;
 
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 
-public record AdvogadoRequestDTO(String nome, String email, String senha, String oab, Role role) {}
+public record AdvogadoRequestDTO(String nome,
+                                 String email,
+                                 String senha,
+                                 String oab,
+                                 String whatsapp,
+                                 String areasAtuacao,
+                                 Role role) {}
 

--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/Advogados/AdvogadoResponseDTO.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/Advogados/AdvogadoResponseDTO.java
@@ -1,3 +1,8 @@
 package advogados_popular.api_advogados_popular.DTOs.Advogados;
 
-public record AdvogadoResponseDTO(Long id, String nome, String email, String oab) {}
+public record AdvogadoResponseDTO(Long id,
+                                  String nome,
+                                  String email,
+                                  String oab,
+                                  String whatsapp,
+                                  String areasAtuacao) {}

--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/Proposta/PropostaAceiteRequestDTO.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/Proposta/PropostaAceiteRequestDTO.java
@@ -1,0 +1,6 @@
+package advogados_popular.api_advogados_popular.DTOs.Proposta;
+
+import advogados_popular.api_advogados_popular.DTOs.utils.FormaPagamento;
+
+public record PropostaAceiteRequestDTO(FormaPagamento formaPagamento,
+                                       String comprovantePagamento) {}

--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/Proposta/PropostaResponseDTO.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/Proposta/PropostaResponseDTO.java
@@ -1,6 +1,7 @@
 package advogados_popular.api_advogados_popular.DTOs.Proposta;
 
 import advogados_popular.api_advogados_popular.DTOs.statusProposta;
+import advogados_popular.api_advogados_popular.DTOs.utils.FormaPagamento;
 
 import java.math.BigDecimal;
 
@@ -11,5 +12,7 @@ public record PropostaResponseDTO(Long id,
                                   Long usuarioId,
                                   String mensagem,
                                   BigDecimal valorSugerido,
-                                  statusProposta status) {}
+                                  statusProposta status,
+                                  FormaPagamento formaPagamento,
+                                  String comprovantePagamento) {}
 

--- a/src/main/java/advogados_popular/api_advogados_popular/DTOs/utils/FormaPagamento.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/DTOs/utils/FormaPagamento.java
@@ -1,0 +1,6 @@
+package advogados_popular.api_advogados_popular.DTOs.utils;
+
+public enum FormaPagamento {
+    AGORA,
+    DEPOIS
+}

--- a/src/main/java/advogados_popular/api_advogados_popular/Entitys/Advogado.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/Entitys/Advogado.java
@@ -30,6 +30,12 @@ public class Advogado {
     @Column(unique = true, nullable = false)
     private String oab;
 
+    @Column(nullable = false)
+    private String whatsapp;
+
+    @Column(name = "areas_atuacao")
+    private String areasAtuacao;
+
     @OneToMany(mappedBy = "advogado")
     private List<Lance> lances;
 }

--- a/src/main/java/advogados_popular/api_advogados_popular/Entitys/Proposta.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/Entitys/Proposta.java
@@ -1,6 +1,7 @@
 package advogados_popular.api_advogados_popular.Entitys;
 
 import advogados_popular.api_advogados_popular.DTOs.statusProposta;
+import advogados_popular.api_advogados_popular.DTOs.utils.FormaPagamento;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,6 +39,12 @@ public class Proposta {
 
     @Enumerated(EnumType.STRING)
     private statusProposta status;
+
+    @Enumerated(EnumType.STRING)
+    private FormaPagamento formaPagamento;
+
+    @Column(name = "comprovante_pagamento")
+    private String comprovantePagamento;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/advogados_popular/api_advogados_popular/controllers/PropostaController.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/controllers/PropostaController.java
@@ -2,6 +2,7 @@ package advogados_popular.api_advogados_popular.controllers;
 
 import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaResponseDTO;
+import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaAceiteRequestDTO;
 import advogados_popular.api_advogados_popular.sevices.PropostaService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +36,8 @@ public class PropostaController {
     }
 
     @PostMapping("/{id}/aceitar")
-    public ResponseEntity<PropostaResponseDTO> aceitar(@PathVariable("id") Long id) {
-        return ResponseEntity.ok(service.aceitar(id));
+    public ResponseEntity<PropostaResponseDTO> aceitar(@PathVariable("id") Long id,
+                                                       @RequestBody(required = false) PropostaAceiteRequestDTO dto) {
+        return ResponseEntity.ok(service.aceitar(id, dto));
     }
 }

--- a/src/main/java/advogados_popular/api_advogados_popular/sevices/AdvogadoService.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/sevices/AdvogadoService.java
@@ -43,9 +43,18 @@ public class AdvogadoService {
         advogado.setAccount(savedAccount);
         advogado.setNome(dto.nome());
         advogado.setOab(dto.oab());
+        advogado.setWhatsapp(dto.whatsapp());
+        advogado.setAreasAtuacao(dto.areasAtuacao());
         Advogado savedAdvogado = advogadoRepository.save(advogado);
 
-        return new AdvogadoResponseDTO(savedAdvogado.getId(), savedAdvogado.getNome(), savedAdvogado.getOab(), savedAccount.getEmail());
+        return new AdvogadoResponseDTO(
+                savedAdvogado.getId(),
+                savedAdvogado.getNome(),
+                savedAccount.getEmail(),
+                savedAdvogado.getOab(),
+                savedAdvogado.getWhatsapp(),
+                savedAdvogado.getAreasAtuacao()
+        );
     }
 }
 

--- a/src/main/java/advogados_popular/api_advogados_popular/sevices/PropostaService.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/sevices/PropostaService.java
@@ -2,6 +2,7 @@ package advogados_popular.api_advogados_popular.sevices;
 
 import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaResponseDTO;
+import advogados_popular.api_advogados_popular.DTOs.Proposta.PropostaAceiteRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.Entitys.*;
@@ -62,7 +63,9 @@ public class PropostaService {
                 causa.getUsuario().getId(),
                 salva.getMensagem(),
                 salva.getValorSugerido(),
-                salva.getStatus()
+                salva.getStatus(),
+                salva.getFormaPagamento(),
+                salva.getComprovantePagamento()
         );
     }
 
@@ -86,7 +89,9 @@ public class PropostaService {
                         causa.getUsuario().getId(),
                         p.getMensagem(),
                         p.getValorSugerido(),
-                        p.getStatus()))
+                        p.getStatus(),
+                        p.getFormaPagamento(),
+                        p.getComprovantePagamento()))
                 .toList();
     }
 
@@ -111,7 +116,9 @@ public class PropostaService {
                         p.getCausa().getUsuario().getId(),
                         p.getMensagem(),
                         p.getValorSugerido(),
-                        p.getStatus()
+                        p.getStatus(),
+                        p.getFormaPagamento(),
+                        p.getComprovantePagamento()
                 ))
                 .toList();
     }
@@ -121,10 +128,14 @@ public class PropostaService {
                 .map(Proposta::getCausa)
                 .toList();
     }
-    public PropostaResponseDTO aceitar(Long propostaId) {
+    public PropostaResponseDTO aceitar(Long propostaId, PropostaAceiteRequestDTO dto) {
         Proposta proposta = propostaRepository.findById(propostaId)
                 .orElseThrow(() -> new RuntimeException("Proposta n�o encontrada"));
         proposta.setStatus(statusProposta.ACEITA);
+        if (dto != null) {
+            proposta.setFormaPagamento(dto.formaPagamento());
+            proposta.setComprovantePagamento(dto.comprovantePagamento());
+        }
         Proposta salva = propostaRepository.save(proposta);
         return new PropostaResponseDTO(
                 salva.getId(),
@@ -134,7 +145,9 @@ public class PropostaService {
                 salva.getCausa().getUsuario().getId(),
                 salva.getMensagem(),
                 salva.getValorSugerido(),
-                salva.getStatus()
+                salva.getStatus(),
+                salva.getFormaPagamento(),
+                salva.getComprovantePagamento()
         );
     }
 }


### PR DESCRIPTION
## Summary
- capture lawyers' WhatsApp and practice areas during registration
- allow clients to specify payment method and upload proof when accepting proposals

## Testing
- `./mvnw -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9da27fa88325b20f129ff391809b