### PR TITLE
Limit historico endpoint to last 15 cases

### DIFF
--- a/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
+++ b/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Comparator;
 
 
 @Service
@@ -85,6 +86,8 @@ public class CausaService {
                     .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
             return causaRepository.findByUsuario(usuario).stream()
                     .filter(c -> filtro == null || c.getStatus() == filtro)
+                    .sorted(Comparator.comparing(Causa::getId).reversed())
+                    .limit(15)
                     .map(c -> new CausaResponseDTO(
                             c.getId(),
                             c.getTitulo(),
@@ -104,6 +107,8 @@ public class CausaService {
                     .map(Proposta::getCausa)
                     .distinct()
                     .filter(c -> filtro == null || c.getStatus() == filtro)
+                    .sorted(Comparator.comparing(Causa::getId).reversed())
+                    .limit(15)
                     .map(c -> new CausaResponseDTO(
                             c.getId(),
                             c.getTitulo(),


### PR DESCRIPTION
## Summary
- order historical cases by newest first and limit responses to 15 items for both users and lawyers

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b92e95548325916b8bcc88609e08